### PR TITLE
Drupal Coding Standards

### DIFF
--- a/emulsify_tools.services.yml
+++ b/emulsify_tools.services.yml
@@ -11,7 +11,8 @@ services:
       - { name: twig.extension }
   emulsify_tools.commands:
     class: Drupal\emulsify_tools\Drush\Commands\SubThemeCommands
-    arguments: ['@file_system']
+    arguments: ['@extension.list.theme', '@plugin.manager.archiver', '@emulsify_tools.subtheme_generator', '@file_system']
     tags:
       - { name: drush.command }
-
+  emulsify_tools.subtheme_generator:
+    class: Drupal\emulsify_tools\SubThemeGenerator

--- a/src/SubThemeGenerator.php
+++ b/src/SubThemeGenerator.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace Drupal\emulsify_tools\Drush\Commands;
+namespace Drupal\emulsify_tools;
 
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

- Checked the code against `phpcs` with the Drupal standard and refactored the following
- Added dependency injection to the `SubThemeCommands` for 3 services
- Moved `SubThemeGenerator` to a service
- Cleaned up unused use statements

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Prepares the module for Drupal.org and best coding practices.

## Documentation update (required)

No changes to documentation, command works exactly the same way as before.

## How to review this pull request
- [x] Pull down this repo into the `/web/modules/contrib` directory  and switch to this branch
- [x] Pull down the `emulsify_drupal` repo into the `/web/themes/contrib` directory and switch to the `release-base-theme` branch.
- [x] Enable the Emulsify Tools module - `drush en emulsify_tools`
- [x] Run the command `drush emulsify my_awesome_theme`
- [x] Verify that a new sub theme is generated in `/web/themes/custom/my_awesome_theme`