### PR TITLE
Add checks for context attributes

### DIFF
--- a/src/AddAttributesTwigExtension.php
+++ b/src/AddAttributesTwigExtension.php
@@ -32,6 +32,12 @@ class AddAttributesTwigExtension extends AbstractExtension {
   public function addAttributes($context, $additional_attributes = []) {
     $attributes = new Attribute();
 
+    // If context attributes doesn't exist or is an array, create new Attribute.
+    $context['attributes'] = $context['attributes'] ?? new Attribute();
+    if (is_array($context['attributes'])) {
+      $context['attributes'] = new Attribute($context['attributes']);
+    }
+
     if (!empty($additional_attributes)) {
       foreach ($additional_attributes as $key => $value) {
 

--- a/src/BemTwigExtension.php
+++ b/src/BemTwigExtension.php
@@ -101,6 +101,13 @@ class BemTwigExtension extends AbstractExtension {
       }
       if (class_exists('Drupal')) {
         $attributes = new Attribute();
+
+        // If context attributes doesn't exist or is an array, create new Attribute.
+        $context['attributes'] = $context['attributes'] ?? new Attribute();
+        if (is_array($context['attributes'])) {
+          $context['attributes'] = new Attribute($context['attributes']);
+        }
+
         // Checking the attributes from the context.
         if (!empty($context['attributes'])) {
           // Iterate the attributes available in context.


### PR DESCRIPTION
## Summary

Note: This was already approved and merged in `emulsify_twig` as part of [PR-61](https://github.com/emulsify-ds/emulsify_twig/pull/61)

The changes didn't make their way into `emulsify_tools`.

---

The fix includes a check of `$context['attributes']` to see if it exists and if not, create a `new Attribute()`. If it did exist in the first place, a secondary check makes sure that if it's an array, to create an Attribute object from that array.

This fix is based on issues reported on the Drupal.org issue queue:
- https://www.drupal.org/project/emulsify_twig/issues/3160391
- https://www.drupal.org/project/emulsify_twig/issues/3302662
- https://www.drupal.org/project/emulsify_twig/issues/3210140

## Fixes

- Checks `$context['attributes']` to see if it exists and if not, create a `new Attribute()`.
- If `$context['attributes']` did exist in the first place, a secondary check makes sure that if it's an array, to create an `Attribute` object from that array.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Sometimes the `$context` variable does not supply attributes as per https://www.drupal.org/project/emulsify_twig/issues/3160391

Because of this, there are times when it was assumed to be an `Attribute` object and therefore would throw errors as per https://www.drupal.org/project/emulsify_twig/issues/3210140

Finally, there could be times when the `$context['attributes']` is an array. If so, it should be converted to an `Attribute` object based on that array as per https://www.drupal.org/project/emulsify_twig/issues/3302662

## Documentation update (required)

None - this is an internal change only.

## How to review this pull request
- [x] One method that caused these errors was by calling the `twig_render_template` function as was mentioned in https://www.drupal.org/project/emulsify_twig/issues/3210140. This can be replicated with updated code:

```
function MY_THEME_preprocess_page(&$variables) {
  $markup = twig_render_template(\Drupal::service('extension.list.theme')->getPath('MY_THEME') . '/templates/content/node.html.twig', ['content' => 'test content']);
}
```

The output above doesn't necessarily need to be actually rendered, just this call did produce the error prior to this fix.

- [x] Other ways of testing this could include testing content using templates with `bem` and `add_attributes` in use, inside views, views with Ajax pagers, and search results pages - essentially places that aren't "typical" view modes.

## Closing issues

Closes Drupal.org issues listed above.