### PR TITLE
Add Twig switch/case extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ Can also be used with the BEM Function:
 <div {{ add_attributes(additional_attributes) }}></div>
 ```
 
+### Switch Case Twig Extension
+
+This adds the ability to do a `switch/case` function from within Twig templates. To use:
+
+```twig
+{% switch content.field_name.0 %}
+    {% case "text" %}
+      <p>This appears if the field name value is set to "text"</p>
+    {% case "image" %}
+      <p>This appears if the field name value is set to "image"</p>
+    {% default %}
+      <p>The field text did not match any case.</p>
+{% endswitch %}
+```
+
+Note that the `switch`, `endswitch`, and `case` tags are required and the `default` is optional.
+
 ## Development
 
 ---

--- a/emulsify_tools.services.yml
+++ b/emulsify_tools.services.yml
@@ -16,3 +16,7 @@ services:
       - { name: drush.command }
   emulsify_tools.subtheme_generator:
     class: Drupal\emulsify_tools\SubThemeGenerator
+  emulsify_tools.twig.switch:
+    class: Drupal\emulsify_tools\SwitchExtension
+    tags:
+      - { name: twig.extension }

--- a/src/SwitchExtension.php
+++ b/src/SwitchExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\emulsify_tools;
+
+use Twig\Extension\AbstractExtension;
+
+/**
+ * Creates a new switch case extension for Twig.
+ */
+class SwitchExtension extends AbstractExtension {
+
+  /**
+   * Gets token parsers.
+   */
+  public function getTokenParsers() {
+    return [
+      new SwitchTokenParser(),
+    ];
+  }
+
+}

--- a/src/SwitchNode.php
+++ b/src/SwitchNode.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\emulsify_tools;
+
+use Twig\Compiler;
+use Twig\Node\Node;
+
+/**
+ * Class SwitchNode. Based on Craft CMS.
+ *
+ * @see https://github.com/craftcms/cms.
+ */
+class SwitchNode extends Node {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function compile(Compiler $compiler): void {
+    $compiler
+      ->addDebugInfo($this)
+      ->write('switch (')
+      ->subcompile($this->getNode('value'))
+      ->raw(") {\n")
+      ->indent();
+
+    foreach ($this->getNode('cases') as $case) {
+      /** @var Twig\Node\Node $case */
+      /* The 'body' node may have been removed by Twig if it was an empty text
+       * node in a sub-template, outside of any blocks.
+       */
+      if (!$case->hasNode('body')) {
+        continue;
+      }
+
+      foreach ($case->getNode('values') as $value) {
+        $compiler
+          ->write('case ')
+          ->subcompile($value)
+          ->raw(":\n");
+      }
+
+      $compiler
+        ->write("{\n")
+        ->indent()
+        ->subcompile($case->getNode('body'))
+        ->write("break;\n")
+        ->outdent()
+        ->write("}\n");
+    }
+
+    if ($this->hasNode('default')) {
+      $compiler
+        ->write("default:\n")
+        ->write("{\n")
+        ->indent()
+        ->subcompile($this->getNode('default'))
+        ->outdent()
+        ->write("}\n");
+    }
+
+    $compiler
+      ->outdent()
+      ->write("}\n");
+  }
+
+}

--- a/src/SwitchTokenParser.php
+++ b/src/SwitchTokenParser.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\emulsify_tools;
+
+use Twig\Error\SyntaxError;
+use Twig\Node\Node;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+/**
+ * Class SwitchTokenParser that parses {% switch %} tags. Based on Craft CMS.
+ *
+ * @see https://github.com/craftcms/cms.
+ */
+class SwitchTokenParser extends AbstractTokenParser {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTag(): string {
+    return 'switch';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function parse(Token $token): SwitchNode {
+    $lineno = $token->getLine();
+    $parser = $this->parser;
+    $stream = $parser->getStream();
+
+    $nodes = [
+      'value' => $parser->getExpressionParser()->parseExpression(),
+    ];
+
+    $stream->expect(Token::BLOCK_END_TYPE);
+
+    // Trim whitespace between the {% switch %} and first {% case %} tag.
+    while ($stream->getCurrent()->getType() == Token::TEXT_TYPE && trim($stream->getCurrent()->getValue()) === '') {
+      $stream->next();
+    }
+
+    $stream->expect(Token::BLOCK_START_TYPE);
+
+    $expressionParser = $parser->getExpressionParser();
+    $cases = [];
+    $end = FALSE;
+
+    while (!$end) {
+      $next = $stream->next();
+
+      switch ($next->getValue()) {
+        case 'case':
+          $values = [];
+          while (TRUE) {
+            $values[] = $expressionParser->parsePrimaryExpression();
+            // Multiple allowed values?
+            if ($stream->test(Token::OPERATOR_TYPE, 'or')) {
+              $stream->next();
+            }
+            else {
+              break;
+            }
+          }
+          $stream->expect(Token::BLOCK_END_TYPE);
+          $body = $parser->subparse([$this, 'decideIfFork']);
+          $cases[] = new Node([
+            'values' => new Node($values),
+            'body' => $body,
+          ]);
+          break;
+
+        case 'default':
+          $stream->expect(Token::BLOCK_END_TYPE);
+          $nodes['default'] = $parser->subparse([$this, 'decideIfEnd']);
+          break;
+
+        case 'endswitch':
+          $end = TRUE;
+          break;
+
+        default:
+          throw new SyntaxError(sprintf('Unexpected end of template. Twig was looking for the following tags "case", "default", or "endswitch" to close the "switch" block started at line %d)', $lineno), -1);
+      }
+    }
+
+    $nodes['cases'] = new Node($cases);
+
+    $stream->expect(Token::BLOCK_END_TYPE);
+
+    return new SwitchNode($nodes, [], $lineno, $this->getTag());
+  }
+
+  /**
+   * Decide IF Fork.
+   *
+   * @param Twig\Token $token
+   *   The token to parse.
+   *
+   * @return bool
+   *   Returns if one of the tokens is part of this switch statement.
+   */
+  public function decideIfFork(Token $token): bool {
+    return $token->test(['case', 'default', 'endswitch']);
+  }
+
+  /**
+   * Decides if end of switch statement.
+   *
+   * @param Twig\Token $token
+   *   The token to parse.
+   *
+   * @return bool
+   *   Returns if we are at the end of the switch statement.
+   */
+  public function decideIfEnd(Token $token): bool {
+    return $token->test(['endswitch']);
+  }
+
+}


### PR DESCRIPTION
## Summary

Adds a new switch/case extension to Twig allowing for switch/case from within templates.

This PR fixes/implements the following **bugs/features**

- Adds a new Twig extension for switch/case statements
- Updates `README.md` with documentation on how to use this new feature

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Continue adding new functionality to Emulsify Tools.

## Documentation update (required)

Yes. `README.md` was updated with new information also copied here for eventual inclusion on the Emulsify website:

This adds the ability to do a `switch/case` function from within Twig templates. To use:

```twig
{% switch content.field_name.0 %}
    {% case "text" %}
      <p>This appears if the field name value is set to "text"</p>
    {% case "image" %}
      <p>This appears if the field name value is set to "image"</p>
    {% default %}
      <p>The field text did not match any case.</p>
{% endswitch %}
```

Note that the `switch`, `endswitch`, and `case` tags are required and the `default` is optional.

## How to review this pull request

- [x] Add the following to the `composer.json` `repositories` section:

```json
{
  "type": "vcs",
  "url": "https://github.com/emulsify-ds/emulsify_tools.git"
}
```
- [x] Go into your modules folder and delete any existing `emulsify_tools` that are already there
- [x] From the root of the project, run `composer require emulsify-ds/emulsify_tools --prefer-source`
- [x] Go into the directory where `emulsify_tools` now resides
- [x] Change to this branch `git checkout switch-case`
- [x] Make sure `emulsify_tools` is installed
- [x] Go into a Twig template and write something like this:

```twig
{% set variable_name = "item 1" %}

{% switch variable_name %}
  {% case "item 1" %}
    Do something here only if the variable is set to "item 1"
  {% case "item 2" %}
    item 2 things
  {% default %}
    This is default if the variable doesn't match
{% endswitch %}
```

- [x] Verify that the switch/case statement works as intended
- [x] Change the variable to "item 2" and verify that the output is different
- [x] Verify that by removing the optional `default` tag, that the function still runs as intended
- [x] Test other uses cases such as: from within a `for` loop
