### PR TITLE
Escaping the css classes added here to prevent xss and other security issues

### DIFF
--- a/src/BemTwigExtension.php
+++ b/src/BemTwigExtension.php
@@ -5,6 +5,7 @@ namespace Drupal\emulsify_tools;
 use Drupal\Core\Template\Attribute;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
+use Drupal\Component\Utility\Html;
 
 /**
  * Class DefaultService.
@@ -129,6 +130,10 @@ class BemTwigExtension extends AbstractExtension {
         }
         // Add class attribute.
         if (!empty($classes)) {
+          // Escape the css classes added to prevent security issues.
+          $classes = array_map(function($css_class) {
+            return Html::cleanCssIdentifier($css_class);
+          }, $classes);
           $attributes->setAttribute('class', $classes);
         }
         return $attributes;


### PR DESCRIPTION
The css classes added by the current implementation are not escaped and could lead to at least xss when malign strings are passed as arguments to the bem() function.

Escaping each css class with drupal's Html::cleanCssIdentifier method mitigates these issues.
