### PR TITLE
Codex/php84 compat tests

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -1,0 +1,31 @@
+name: PHP Compatibility
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "*.x"
+
+jobs:
+  lint:
+    name: PHP ${{ matrix.php-version }} lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "8.4"
+          - "8.5"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - name: Lint PHP sources
+        run: git ls-files '*.php' | xargs -n 1 php -l

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This module provides Emulsify Twig extensions, theme-defined Twig namespaces, an
 
 ## Compatibility
 
-This module now targets Drupal `11.3+`.
+This module now targets Drupal `11.3+` and PHP `8.4+`.
 
-The bundled Drush command follows the Drush 13+ autowiring pattern.
+The bundled Drush command follows the Drush 13+ autowiring pattern, and the
+codebase now uses PHP 8.4-only syntax where it improves readability.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://emulsify.info",
   "license": "GPL-2.0-only",
   "require": {
-    "php": ">=8.3",
+    "php": "^8.4",
     "drupal/core": "^11.3"
   },
   "conflict": {

--- a/src/Drush/Commands/SubThemeCommands.php
+++ b/src/Drush/Commands/SubThemeCommands.php
@@ -245,7 +245,7 @@ final class SubThemeCommands extends DrushCommands implements BuilderAwareInterf
    *   The finder.
    */
   private function getDirectDescendants(string $dir): Finder {
-    return (new Finder())
+    return new Finder()
       ->in($dir)
       ->depth('== 0');
   }

--- a/src/SubThemeGenerator.php
+++ b/src/SubThemeGenerator.php
@@ -56,7 +56,7 @@ final class SubThemeGenerator {
    *   The original machine name.
    */
   private function discoverOriginalMachineName(string $directory): string {
-    $finder = (new Finder())
+    $finder = new Finder()
       ->files()
       ->depth('== 0')
       ->in($directory)
@@ -140,7 +140,7 @@ final class SubThemeGenerator {
    */
   private function getFileNamesToRename(string $directory, string $originalMachineName): array {
     $fileNames = [];
-    $finder = (new Finder())
+    $finder = new Finder()
       ->files()
       ->in($directory)
       ->name("*{$originalMachineName}*");
@@ -165,7 +165,7 @@ final class SubThemeGenerator {
    */
   private function getDirectoryNamesToRename(string $directory, string $originalMachineName): array {
     $directoryNames = [];
-    $finder = (new Finder())
+    $finder = new Finder()
       ->directories()
       ->in($directory)
       ->name("*{$originalMachineName}*");
@@ -211,7 +211,7 @@ final class SubThemeGenerator {
    */
   private function getFilesToMakeReplacements(string $directory): array {
     $fileNames = [];
-    $finder = (new Finder())
+    $finder = new Finder()
       ->files()
       ->in($directory);
 

--- a/src/Twig/ThemeNamespaceRegistry.php
+++ b/src/Twig/ThemeNamespaceRegistry.php
@@ -51,6 +51,13 @@ final class ThemeNamespaceRegistry {
   private array $warnedNamespaces = [];
 
   /**
+   * Protected default namespaces keyed by namespace.
+   *
+   * @var array<string, array{name: string, type: string}>|null
+   */
+  private ?array $protectedNamespaces = NULL;
+
+  /**
    * Creates the registry.
    */
   public function __construct(
@@ -316,18 +323,81 @@ final class ThemeNamespaceRegistry {
   }
 
   /**
-   * Returns whether the namespace would shadow a default Drupal namespace.
+   * Returns protected default namespaces keyed by namespace.
+   *
+   * @return array<string, array{name: string, type: string}>
+   *   Protected default namespace owner metadata.
+   */
+  private function getProtectedNamespaces(): array {
+    return $this->protectedNamespaces ??= $this->buildProtectedNamespaces();
+  }
+
+  /**
+   * Builds protected default namespaces for installed modules and themes.
+   *
+   * Extensions may opt into reuse of their default namespace via
+   * `components.allow_default_namespace_reuse` or by defining a matching
+   * default namespace under `components.namespaces`.
+   *
+   * @return array<string, array{name: string, type: string}>
+   *   Protected default namespace owner metadata.
+   */
+  private function buildProtectedNamespaces(): array {
+    $protectedNamespaces = [];
+
+    foreach ($this->moduleExtensionList->getList() as $extensionName => $extension) {
+      if (!$extension instanceof Extension || $this->allowsDefaultNamespaceReuse($extension)) {
+        continue;
+      }
+
+      $protectedNamespaces[$extensionName] = [
+        'name' => (string) ($extension->info['name'] ?? $extensionName),
+        'type' => 'module',
+      ];
+    }
+
+    // Themes win ties to match Drupal's existing namespace precedence.
+    foreach ($this->themeExtensionList->getList() as $extensionName => $extension) {
+      if (!$extension instanceof Extension || $this->allowsDefaultNamespaceReuse($extension)) {
+        continue;
+      }
+
+      $protectedNamespaces[$extensionName] = [
+        'name' => (string) ($extension->info['name'] ?? $extensionName),
+        'type' => 'theme',
+      ];
+    }
+
+    return $protectedNamespaces;
+  }
+
+  /**
+   * Returns whether an extension allows reuse of its default namespace.
+   */
+  private function allowsDefaultNamespaceReuse(Extension $extension): bool {
+    $components = $extension->info['components'] ?? NULL;
+    if (!is_array($components)) {
+      return FALSE;
+    }
+
+    // Mirror drupal/components, where presence of the key opts in.
+    if (array_key_exists('allow_default_namespace_reuse', $components)) {
+      return TRUE;
+    }
+
+    $definitions = $components['namespaces'] ?? NULL;
+    return is_array($definitions) && !empty($definitions[$extension->getName()]);
+  }
+
+  /**
+   * Returns whether the namespace would shadow a protected default namespace.
    */
   private function isProtectedNamespace(string $namespace, string $definingThemeName): bool {
     if ($namespace === $definingThemeName) {
       return FALSE;
     }
 
-    if (isset($this->themeExtensionList->getList()[$namespace])) {
-      return TRUE;
-    }
-
-    return isset($this->moduleExtensionList->getList()[$namespace]);
+    return isset($this->getProtectedNamespaces()[$namespace]);
   }
 
   /**
@@ -375,14 +445,9 @@ final class ThemeNamespaceRegistry {
    *   The owner type and human-readable name.
    */
   private function getProtectedNamespaceOwner(string $namespace): array {
-    $theme = $this->themeExtensionList->getList()[$namespace] ?? NULL;
-    if ($theme instanceof Extension) {
-      return ['theme', (string) ($theme->info['name'] ?? $namespace)];
-    }
-
-    $module = $this->moduleExtensionList->getList()[$namespace] ?? NULL;
-    if ($module instanceof Extension) {
-      return ['module', (string) ($module->info['name'] ?? $namespace)];
+    $owner = $this->getProtectedNamespaces()[$namespace] ?? NULL;
+    if (is_array($owner)) {
+      return [$owner['type'], $owner['name']];
     }
 
     return ['extension', $namespace];

--- a/tests/src/Unit/BemTwigExtensionTest.php
+++ b/tests/src/Unit/BemTwigExtensionTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\emulsify_tools\Unit;
+
+use Drupal\Core\Template\Attribute;
+use Drupal\emulsify_tools\BemTwigExtension;
+use Drupal\emulsify_tools\TwigAttributeManager;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the BEM Twig extension.
+ *
+ * @coversDefaultClass \Drupal\emulsify_tools\BemTwigExtension
+ * @group emulsify_tools
+ */
+final class BemTwigExtensionTest extends UnitTestCase {
+
+  /**
+   * Tests positional bem() arguments.
+   *
+   * @covers ::bem
+   */
+  public function testBemBuildsExpectedClassesFromPositionalArguments(): void {
+    $extension = new BemTwigExtension(new TwigAttributeManager());
+    $sourceAttributes = new Attribute([
+      'class' => ['existing'],
+      'data-role' => 'heading',
+    ]);
+
+    $result = $extension->bem(
+      ['attributes' => $sourceAttributes],
+      'title',
+      ['small', 'red'],
+      'card',
+      ['js-click', 'bad value'],
+    );
+
+    $resultArray = $result->toArray();
+
+    self::assertSame([
+      'card__title',
+      'card__title--small',
+      'card__title--red',
+      'js-click',
+      'bad-value',
+      'existing',
+    ], $resultArray['class']);
+    self::assertSame('heading', $resultArray['data-role']);
+  }
+
+  /**
+   * Tests array-style bem() arguments.
+   *
+   * @covers ::bem
+   */
+  public function testBemBuildsExpectedClassesFromConfigurationArray(): void {
+    $extension = new BemTwigExtension(new TwigAttributeManager());
+
+    $result = $extension->bem(
+      [],
+      [
+        'base_class' => 'title',
+        'modifiers' => 'small',
+        'blockname' => 'card',
+        'extra' => ['js-click'],
+      ],
+    );
+
+    self::assertSame([
+      'card__title',
+      'card__title--small',
+      'js-click',
+    ], $result->toArray()['class']);
+  }
+
+}

--- a/tests/src/Unit/SubThemeGeneratorTest.php
+++ b/tests/src/Unit/SubThemeGeneratorTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\emulsify_tools\Unit;
+
+use Drupal\emulsify_tools\SubThemeGenerator;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Tests subtheme generation.
+ *
+ * @coversDefaultClass \Drupal\emulsify_tools\SubThemeGenerator
+ * @group emulsify_tools
+ */
+final class SubThemeGeneratorTest extends UnitTestCase {
+
+  /**
+   * The filesystem helper used by the generator.
+   */
+  private Filesystem $filesystem;
+
+  /**
+   * A temporary directory for fixture files.
+   */
+  private string $temporaryDirectory;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->filesystem = new Filesystem();
+    $this->temporaryDirectory = sys_get_temp_dir() . '/emulsify_tools_' . bin2hex(random_bytes(8));
+    $this->filesystem->mkdir($this->temporaryDirectory);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    if (isset($this->temporaryDirectory) && $this->filesystem->exists($this->temporaryDirectory)) {
+      $this->filesystem->remove($this->temporaryDirectory);
+    }
+
+    parent::tearDown();
+  }
+
+  /**
+   * Tests file, directory, and content replacements during generation.
+   *
+   * @covers ::generate
+   */
+  public function testGenerateRenamesThemeAssetsAndRewritesContent(): void {
+    $themeDirectory = $this->temporaryDirectory . '/theme';
+    $this->filesystem->mkdir([
+      $themeDirectory,
+      $themeDirectory . '/components/whisk-parent/whisk-child',
+    ]);
+
+    $this->writeFile(
+      $themeDirectory . '/whisk.info.emulsify.yml',
+      "name: EMULSIFY_NAME\n",
+    );
+    $this->writeFile(
+      $themeDirectory . '/components/whisk-parent/whisk-child/whisk-template.twig',
+      "machine: whisk\nlabel: EMULSIFY_NAME\n",
+    );
+    $this->writeFile(
+      $themeDirectory . '/README.md',
+      "Theme: EMULSIFY_NAME (whisk)\n",
+    );
+
+    $generator = new SubThemeGenerator($this->filesystem);
+    $generator->generate($themeDirectory, 'new_theme', 'New Theme');
+
+    self::assertFileDoesNotExist($themeDirectory . '/whisk.info.emulsify.yml');
+    self::assertFileExists($themeDirectory . '/new_theme.info.yml');
+    self::assertSame("name: New Theme\n", $this->readFile($themeDirectory . '/new_theme.info.yml'));
+
+    self::assertDirectoryDoesNotExist($themeDirectory . '/components/whisk-parent');
+    self::assertDirectoryExists($themeDirectory . '/components/new_theme-parent/new_theme-child');
+    self::assertFileExists($themeDirectory . '/components/new_theme-parent/new_theme-child/new_theme-template.twig');
+    self::assertSame(
+      "machine: new_theme\nlabel: New Theme\n",
+      $this->readFile($themeDirectory . '/components/new_theme-parent/new_theme-child/new_theme-template.twig'),
+    );
+
+    self::assertSame("Theme: New Theme (new_theme)\n", $this->readFile($themeDirectory . '/README.md'));
+  }
+
+  /**
+   * Tests that the source theme info file is required.
+   *
+   * @covers ::generate
+   */
+  public function testGenerateRequiresAnEmulsifyInfoFile(): void {
+    $themeDirectory = $this->temporaryDirectory . '/missing-info';
+    $this->filesystem->mkdir($themeDirectory);
+
+    $generator = new SubThemeGenerator($this->filesystem);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage(sprintf('No *.info.emulsify.yml file was found in "%s".', $themeDirectory));
+    $generator->generate($themeDirectory, 'new_theme', 'New Theme');
+  }
+
+  /**
+   * Writes a test fixture file.
+   */
+  private function writeFile(string $path, string $contents): void {
+    $result = file_put_contents($path, $contents);
+    if ($result === FALSE) {
+      throw new \RuntimeException(sprintf('Failed to write fixture file "%s".', $path));
+    }
+  }
+
+  /**
+   * Reads a generated file.
+   */
+  private function readFile(string $path): string {
+    $contents = file_get_contents($path);
+    if ($contents === FALSE) {
+      throw new \RuntimeException(sprintf('Failed to read fixture file "%s".', $path));
+    }
+
+    return $contents;
+  }
+
+}

--- a/tests/src/Unit/ThemeNamespaceRegistryTest.php
+++ b/tests/src/Unit/ThemeNamespaceRegistryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\emulsify_tools\Unit;
+
+use Drupal\emulsify_tools\Twig\ThemeNamespaceRegistry;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests Twig namespace template validation.
+ *
+ * @coversDefaultClass \Drupal\emulsify_tools\Twig\ThemeNamespaceRegistry
+ * @group emulsify_tools
+ */
+final class ThemeNamespaceRegistryTest extends UnitTestCase {
+
+  /**
+   * Tests supported and unsupported template names.
+   *
+   * @param string $templateName
+   *   The template name to validate.
+   * @param bool $expected
+   *   The expected validation result.
+   *
+   * @dataProvider providerTemplateNames
+   *
+   * @covers ::isValidTemplateName
+   */
+  public function testIsValidTemplateName(string $templateName, bool $expected): void {
+    self::assertSame($expected, ThemeNamespaceRegistry::isValidTemplateName($templateName));
+  }
+
+  /**
+   * Provides template names for validation tests.
+   *
+   * @return array<string, array{0: string, 1: bool}>
+   *   The template name and expected result.
+   */
+  public static function providerTemplateNames(): array {
+    return [
+      'twig template' => ['@atoms/button.twig', TRUE],
+      'uppercase extension' => ['@atoms/button.TWIG', TRUE],
+      'html template' => ['@atoms/cards/card.html', TRUE],
+      'svg template' => ['@icons/close.svg', TRUE],
+      'missing namespace prefix' => ['atoms/button.twig', FALSE],
+      'missing slash' => ['@atoms', FALSE],
+      'missing namespace name' => ['@/button.twig', FALSE],
+      'missing template path' => ['@atoms/', FALSE],
+      'missing extension' => ['@atoms/button', FALSE],
+      'unsupported extension' => ['@atoms/button.php', FALSE],
+    ];
+  }
+
+}

--- a/tests/src/Unit/TwigAttributeManagerTest.php
+++ b/tests/src/Unit/TwigAttributeManagerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\emulsify_tools\Unit;
+
+use Drupal\Core\Template\Attribute;
+use Drupal\emulsify_tools\TwigAttributeManager;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests attribute normalization for Emulsify Twig helpers.
+ *
+ * @coversDefaultClass \Drupal\emulsify_tools\TwigAttributeManager
+ * @group emulsify_tools
+ */
+final class TwigAttributeManagerTest extends UnitTestCase {
+
+  /**
+   * Tests add_attributes()-style merging and attribute detachment.
+   *
+   * @covers ::mergeContextAttributes
+   */
+  public function testMergeContextAttributesDetachesAndMergesValues(): void {
+    $sourceAttributes = new Attribute([
+      'class' => ['existing', 'existing'],
+      'data-role' => 'banner',
+    ]);
+
+    $manager = new TwigAttributeManager();
+    $result = $manager->mergeContextAttributes(
+      ['attributes' => $sourceAttributes],
+      [
+        'class' => ['new class', 'existing'],
+        'title' => 'Hero',
+        'data-values' => ['first', 'second'],
+      ],
+    );
+
+    $resultArray = $result->toArray();
+
+    self::assertSame(['existing', 'new-class'], $resultArray['class']);
+    self::assertSame('banner', $resultArray['data-role']);
+    self::assertSame('Hero', $resultArray['title']);
+    self::assertSame(['first', 'second'], $resultArray['data-values']);
+    self::assertSame([], $sourceAttributes->toArray());
+  }
+
+  /**
+   * Tests BEM attribute merging preserves generated class precedence.
+   *
+   * @covers ::buildBemAttributes
+   */
+  public function testBuildBemAttributesMergesAndSanitizesClasses(): void {
+    $sourceAttributes = new Attribute([
+      'class' => ['existing', 'bad value'],
+      'data-role' => 'banner',
+    ]);
+
+    $manager = new TwigAttributeManager();
+    $result = $manager->buildBemAttributes(
+      ['attributes' => $sourceAttributes],
+      ['card__title', 'card__title--featured', 'js hook'],
+    );
+
+    $resultArray = $result->toArray();
+
+    self::assertSame([
+      'card__title',
+      'card__title--featured',
+      'js-hook',
+      'existing',
+      'bad-value',
+    ], $resultArray['class']);
+    self::assertSame('banner', $resultArray['data-role']);
+    self::assertSame([], $sourceAttributes->toArray());
+  }
+
+}


### PR DESCRIPTION
**This PR does the following:**

* Updates Emulsify Tools to require PHP `8.4+`.
* Updates the README compatibility notes to document Drupal `11.3+`, PHP `8.4+`, and Drush `13+` expectations.
* Adds a GitHub Actions PHP compatibility workflow that runs PHP linting against PHP `8.4` and `8.5`.
* Updates `ThemeNamespaceRegistry` to better protect default Drupal module/theme Twig namespaces while allowing intentional namespace reuse.
* Adds support for `components.allow_default_namespace_reuse` to opt into reusing an extension’s default namespace.
* Allows namespace reuse when an extension explicitly defines its own matching namespace in `components.namespaces`.
* Refactors several `new Finder()` usages to use PHP 8.4-compatible syntax without unnecessary wrapping parentheses.
* Adds unit test coverage for `BemTwigExtension`.
* Adds unit test coverage for `TwigAttributeManager`.
* Adds unit test coverage for `SubThemeGenerator`.
* Adds unit test coverage for namespaced Twig template validation in `ThemeNamespaceRegistry`.

### Related Issue(s)

* N/A

### Notes:

* This PR builds on the `release-2` branch and assumes the Drupal `11.3+`, PHP `8.4+`, and Drush `13+` compatibility direction from that release line.
* The PHP compatibility workflow currently runs PHP syntax linting only; it does not run the full PHPUnit test suite.
* The namespace protection changes intentionally preserve default Drupal namespace safety while allowing explicit opt-in reuse through `components.allow_default_namespace_reuse`.

### Functional Testing:

* [ ] Confirm Composer accepts the package on PHP `8.4+`.
* [ ] Confirm Composer rejects or flags incompatible PHP versions below `8.4`.
* [ ] Run `composer install`.
* [ ] Enable the module in a Drupal `11.3+` site with `drush en emulsify_tools -y`.
* [ ] Rebuild caches with `drush cr`.
* [ ] Confirm the site rebuilds the service container without PHP errors.
* [ ] Confirm the GitHub Actions PHP Compatibility workflow runs on the PR.
* [ ] Confirm the PHP Compatibility workflow passes for PHP `8.4`.
* [ ] Confirm the PHP Compatibility workflow passes for PHP `8.5`.
* [ ] Run PHP linting locally with `git ls-files '*.php' | xargs -n 1 php -l`.
* [ ] Run the available PHPUnit test suite.
* [ ] Confirm `BemTwigExtensionTest` passes.
* [ ] Confirm `TwigAttributeManagerTest` passes.
* [ ] Confirm `SubThemeGeneratorTest` passes.
* [ ] Confirm `ThemeNamespaceRegistryTest` passes.
* [ ] Generate a subtheme with `drush emulsify "Test Theme"`.
* [ ] Confirm the generated theme appears at `themes/custom/test_theme`.
* [ ] Confirm generated files, directories, and contents are renamed from the starter theme machine name to `test_theme`.
* [ ] Confirm generation fails with a clear exception when the starter source does not contain a `*.info.emulsify.yml` file.
* [ ] Add a custom `components.namespaces` entry to a test theme and confirm namespaced Twig templates still resolve correctly.
* [ ] Attempt to define a namespace that conflicts with an installed module or theme namespace and confirm it is protected unless explicitly allowed.
* [ ] Add `components.allow_default_namespace_reuse` to an extension and confirm its default namespace can be reused.
* [ ] Define a matching namespace under `components.namespaces` and confirm that namespace reuse is allowed.
* [ ] Confirm malformed namespaced Twig references still fail validation.
* [ ] Confirm supported namespaced template extensions still include `.twig`, `.html`, and `.svg`.
* [ ] Confirm unsupported namespaced template extensions, such as `.php`, are rejected.

### Security

*Security checks that should be reviewed*

* Confirm protected Drupal module/theme Twig namespaces cannot be shadowed unintentionally.
* Confirm namespace reuse is only allowed when explicitly opted into through `components.allow_default_namespace_reuse` or a matching namespace definition.
* Confirm namespaced template validation continues to reject malformed template names and unsupported file extensions.
* Confirm the subtheme generator only renames and rewrites files inside the generated theme directory.
* Confirm PHP `8.4+` syntax changes do not alter runtime behavior beyond compatibility/readability improvements.

### Accessibility

*Should this be checked for this feature?*

* No dedicated accessibility review is required for the PHP compatibility workflow, Composer constraint, unit tests, or namespace protection changes.
* Spot check rendered templates that rely on theme-defined Twig namespaces to confirm expected markup, classes, IDs, ARIA attributes, and semantic structure are preserved.
