### PR TITLE
fix: allow PHP 8.3 support

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
+          - "8.3"
           - "8.4"
           - "8.5"
     steps:
@@ -31,7 +32,7 @@ jobs:
         run: git ls-files '*.php' | xargs -n 1 php -l
 
   phpcs:
-    name: PHPCS (PHP 8.4)
+    name: PHPCS (PHP 8.3)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: "8.3"
           coverage: none
 
       - name: Install dependencies
@@ -56,6 +57,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - php-version: "8.3"
+            drupal-core: "^11.3"
+            drupal-label: "^11.3"
           - php-version: "8.4"
             drupal-core: "^11.3"
             drupal-label: "^11.3"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -41,7 +41,9 @@ jobs:
 
       - name: Sync release tags to Drupal.org Project
         if: steps.semantic.outputs.new_release_published == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.semantic.outputs.new_release_git_tag }}
         run: |
           git remote add drupal-org '${{ secrets.DRUPAL_REPO_URL }}'
-          git push drupal-org --tags
+          git push drupal-org "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
           git push drupal-org HEAD:main

--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ This module provides Emulsify Twig extensions, theme-defined Twig namespaces, ch
 
 ## Compatibility
 
-This module targets Drupal `11.3+`, includes Drupal 12 forward compatibility, and requires PHP `8.4+`. Drupal core development branch coverage is experimental until Drupal 12 beta or stable releases are available.
+This module targets Drupal `11.3+`, includes Drupal 12 forward compatibility,
+and supports PHP `8.3+` for Drupal 11 sites. Drupal 12 compatibility follows
+Drupal core's PHP requirements and is tested on PHP `8.5`.
 
 The bundled Drush commands follow the Drush 13+ autowiring pattern, and the
-codebase now uses PHP 8.4-only syntax where it improves readability.
+codebase avoids syntax newer than PHP 8.3 so Drupal 11 sites can keep using
+their supported PHP 8.3 runtimes.
 
 ### Companion theme pairing
 
@@ -288,7 +291,7 @@ changes after running the command.
 
 ### Requires
 
-- [PHP 8.4+](https://www.php.net/)
+- [PHP 8.3+](https://www.php.net/)
 - [Composer 2](https://getcomposer.org/)
 - [Node.js 20.11+](https://nodejs.org/)
 
@@ -360,6 +363,8 @@ There's a two-step process to publish a new release to [the project page](https:
   will calculate the next version from the merged commit messages, update
   `CHANGELOG.md`, create a `[skip ci]` release commit, create the GitHub
   release, and push the release commit and new tag to Drupal.org.
+- Release tags use the semantic version only, such as `2.1.1`, with no `v`
+  prefix.
 - When the workflow completes, confirm the new version appears on the
   [GitHub Releases page](https://github.com/emulsify-ds/emulsify_tools/releases).
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   },
   "require": {
-    "php": "^8.4",
+    "php": "^8.3",
     "drupal/core": "^11.3 || ^12"
   },
   "require-dev": {

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,6 +1,7 @@
 // release.config.cjs
 module.exports = {
   branches: ['main'],
+  tagFormat: '${version}',
   repositoryUrl: 'https://github.com/emulsify-ds/emulsify_tools.git',
   plugins: [
     [

--- a/src/Drush/Commands/SubThemeCommands.php
+++ b/src/Drush/Commands/SubThemeCommands.php
@@ -372,7 +372,7 @@ final class SubThemeCommands extends DrushCommands {
    *   The finder.
    */
   private function getDirectDescendants(string $dir): Finder {
-    return new Finder()
+    return (new Finder())
       ->in($dir)
       ->depth('== 0');
   }

--- a/src/SubThemeGenerator.php
+++ b/src/SubThemeGenerator.php
@@ -76,7 +76,7 @@ final class SubThemeGenerator {
    *   The original machine name.
    */
   private function discoverOriginalMachineName(string $directory): string {
-    $finder = new Finder()
+    $finder = (new Finder())
       ->files()
       ->depth('== 0')
       ->in($directory)
@@ -158,7 +158,7 @@ final class SubThemeGenerator {
    */
   private function getFileNamesToRename(string $directory, string $originalMachineName): array {
     $fileNames = [];
-    $finder = new Finder()
+    $finder = (new Finder())
       ->files()
       ->in($directory)
       ->name("*{$originalMachineName}*");
@@ -183,7 +183,7 @@ final class SubThemeGenerator {
    */
   private function getDirectoryNamesToRename(string $directory, string $originalMachineName): array {
     $directoryNames = [];
-    $finder = new Finder()
+    $finder = (new Finder())
       ->directories()
       ->in($directory)
       ->name("*{$originalMachineName}*");
@@ -229,7 +229,7 @@ final class SubThemeGenerator {
    */
   private function getFilesToMakeReplacements(string $directory): array {
     $fileNames = [];
-    $finder = new Finder()
+    $finder = (new Finder())
       ->files()
       ->in($directory);
 


### PR DESCRIPTION
Here’s a PR description following the current repo template:

## Summary
- Lower the package PHP floor from `^8.4` to `^8.3` so Drupal 11 sites can install the module on PHP 8.3-supported runtimes.
- Keep Drupal 12 compatibility guarded by Drupal core's own PHP requirements, with CI coverage continuing on PHP 8.5.
- Add PHP 8.3 coverage to syntax linting, PHPCS, and the Drupal `^11.3` PHPUnit matrix.
- Configure semantic-release to create unprefixed semver tags, such as `2.1.1`, and push only the generated release tag to Drupal.org.

## Related Issue(s)
- None.

## Validation
- [x] `composer validate --no-check-publish`
- [x] `composer lint:phpcs`
- [x] `composer test:unit`
- [x] `composer test:deprecations`
- [x] PHP syntax lint across tracked PHP files
- [x] Disposable Composer solve for PHP `8.3.99` with Drupal 11 dependencies
- [x] Disposable Composer solve for Drupal `12.x-dev@dev` on PHP `8.5`
- [ ] `npm run lint` not run
- [ ] Manual Drupal verification not applicable; no Drupal UI or runtime behavior changed

## Notes
- This is a `fix:` commit, so merging to `main` should trigger a patch release.
- With the current release config, the expected next tag is `2.1.1` rather than `v2.1.1`.
- PHP 8.3 support applies to Drupal 11. Drupal 12 compatibility continues to follow Drupal core's PHP requirements.

## Security
- No security impact.
- This changes package metadata, CI coverage, documentation, and release tag handling only; it does not change access control, file-system writes, or output sanitization.

## Accessibility
- No accessibility impact.
- This PR does not change UI, generated markup, focus behavior, ARIA, or frontend output.
