### PR TITLE
fix: generated theme visibility

### DIFF
--- a/src/SubThemeGenerator.php
+++ b/src/SubThemeGenerator.php
@@ -48,7 +48,7 @@ final class SubThemeGenerator {
       $this->renameFiles($directory, $originalMachineName, $machineName);
     }
 
-    $this->removeGeneratedThemeHiddenFlag($directory, $machineName);
+    $this->updateGeneratedThemeInfo($directory, $machineName);
   }
 
   /**
@@ -148,23 +148,34 @@ final class SubThemeGenerator {
   }
 
   /**
-   * Makes the generated theme visible without exposing the source starterkit.
+   * Applies generated-only visibility and version metadata.
    */
-  private function removeGeneratedThemeHiddenFlag(string $directory, string $machineName): void {
+  private function updateGeneratedThemeInfo(string $directory, string $machineName): void {
     $fileName = "{$directory}/{$machineName}.info.yml";
     $content = preg_replace(
       '/^hidden:[ \t]*true[ \t]*(?:\R|$)/m',
       '',
       $this->fileGetContents($fileName),
-      -1,
-      $count,
     );
     if ($content === NULL) {
       throw new \RuntimeException(sprintf("Could not update file '%s'.", $fileName));
     }
-    if ($count > 0) {
-      $this->filesystem->dumpFile($fileName, $content);
+
+    $content = preg_replace(
+      '/^version:[^\r\n]*(?:\R|$)/m',
+      "version: '1.0.0'\n",
+      $content,
+      -1,
+      $versionCount,
+    );
+    if ($content === NULL) {
+      throw new \RuntimeException(sprintf("Could not update file '%s'.", $fileName));
     }
+    if ($versionCount === 0) {
+      $content = rtrim($content, "\r\n") . "\nversion: '1.0.0'\n";
+    }
+
+    $this->filesystem->dumpFile($fileName, $content);
   }
 
   /**

--- a/src/SubThemeGenerator.php
+++ b/src/SubThemeGenerator.php
@@ -47,6 +47,8 @@ final class SubThemeGenerator {
       $this->renameDirectories($directory, $originalMachineName, $machineName);
       $this->renameFiles($directory, $originalMachineName, $machineName);
     }
+
+    $this->removeGeneratedThemeHiddenFlag($directory, $machineName);
   }
 
   /**
@@ -143,6 +145,26 @@ final class SubThemeGenerator {
       $fileName,
       strtr($this->fileGetContents($fileName), $replacementPairs),
     );
+  }
+
+  /**
+   * Makes the generated theme visible without exposing the source starterkit.
+   */
+  private function removeGeneratedThemeHiddenFlag(string $directory, string $machineName): void {
+    $fileName = "{$directory}/{$machineName}.info.yml";
+    $content = preg_replace(
+      '/^hidden:[ \t]*true[ \t]*(?:\R|$)/m',
+      '',
+      $this->fileGetContents($fileName),
+      -1,
+      $count,
+    );
+    if ($content === NULL) {
+      throw new \RuntimeException(sprintf("Could not update file '%s'.", $fileName));
+    }
+    if ($count > 0) {
+      $this->filesystem->dumpFile($fileName, $content);
+    }
   }
 
   /**

--- a/tests/src/Unit/SubThemeCommandsTest.php
+++ b/tests/src/Unit/SubThemeCommandsTest.php
@@ -172,7 +172,7 @@ final class SubThemeCommandsTest extends UnitTestCase {
   private function writeStarterRecipe(string $directory): void {
     $this->filesystem->mkdir($directory);
     $this->writeFile($directory . '/whisk.info.emulsify.yml', "hidden: false\n");
-    $this->writeFile($directory . '/whisk.info.yml', "name: EMULSIFY_NAME\n");
+    $this->writeFile($directory . '/whisk.info.yml', "name: EMULSIFY_NAME\nhidden: true\n");
   }
 
   /**

--- a/tests/src/Unit/SubThemeCommandsTest.php
+++ b/tests/src/Unit/SubThemeCommandsTest.php
@@ -128,7 +128,10 @@ final class SubThemeCommandsTest extends UnitTestCase {
 
     $generatedInfoFile = $this->temporaryDirectory . '/themes/custom/happy_theme/happy_theme.info.yml';
     self::assertFileExists($generatedInfoFile);
-    self::assertSame("name: Happy Theme\n", $this->readFile($generatedInfoFile));
+    self::assertSame(
+      "name: Happy Theme\nversion: '1.0.0'\n",
+      $this->readFile($generatedInfoFile),
+    );
     self::assertTrue($logger->hasNoticeContaining('Using "happy_theme"', 'Happy Theme'));
   }
 

--- a/tests/src/Unit/SubThemeGeneratorTest.php
+++ b/tests/src/Unit/SubThemeGeneratorTest.php
@@ -61,7 +61,7 @@ final class SubThemeGeneratorTest extends UnitTestCase {
 
     $this->writeFile(
       $themeDirectory . '/whisk.info.yml',
-      "name: EMULSIFY_NAME\n",
+      "name: EMULSIFY_NAME\nhidden: true\n",
     );
     $this->writeFile(
       $themeDirectory . '/whisk.info.emulsify.yml',

--- a/tests/src/Unit/SubThemeGeneratorTest.php
+++ b/tests/src/Unit/SubThemeGeneratorTest.php
@@ -61,7 +61,7 @@ final class SubThemeGeneratorTest extends UnitTestCase {
 
     $this->writeFile(
       $themeDirectory . '/whisk.info.yml',
-      "name: EMULSIFY_NAME\nhidden: true\n",
+      "name: EMULSIFY_NAME\nversion: '7.1.1'\nhidden: true\n",
     );
     $this->writeFile(
       $themeDirectory . '/whisk.info.emulsify.yml',
@@ -91,7 +91,10 @@ final class SubThemeGeneratorTest extends UnitTestCase {
     self::assertFileDoesNotExist($themeDirectory . '/whisk.starterkit.yml');
     self::assertFileDoesNotExist($themeDirectory . '/project.emulsify.json');
     self::assertFileExists($themeDirectory . '/new_theme.info.yml');
-    self::assertSame("name: New Theme\n", $this->readFile($themeDirectory . '/new_theme.info.yml'));
+    self::assertSame(
+      "name: New Theme\nversion: '1.0.0'\n",
+      $this->readFile($themeDirectory . '/new_theme.info.yml'),
+    );
 
     self::assertDirectoryDoesNotExist($themeDirectory . '/components/whisk-parent');
     self::assertDirectoryExists($themeDirectory . '/components/new_theme-parent/new_theme-child');


### PR DESCRIPTION
## Summary
- Removes the `hidden: true` from the generated theme. This is necessary for `whisk` but not for the generated theme.